### PR TITLE
Bump 'ramsey/uuid' version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "ramsey/uuid": "^3.9"
+        "ramsey/uuid": "^3.9 || ^4.0"
     },
     "require-dev": {
         "orchestra/testbench": "^3.5 || ^4.0 || ^5.0",


### PR DESCRIPTION
This **PR** fixes #5 

The package dependecy **ramsey/uuid** was [updated in Laravel 7](https://github.com/laravel/framework/pull/32086).