### PR TITLE
Support multiple connections

### DIFF
--- a/src/Traits/HasUuid.php
+++ b/src/Traits/HasUuid.php
@@ -12,7 +12,6 @@
 namespace YourAppRocks\EloquentUuid\Traits;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Facades\Schema;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 use YourAppRocks\EloquentUuid\Exceptions\MissingUuidColumnException;
 
@@ -82,7 +81,7 @@ trait HasUuid
      */
     private function hasColumnUuid($model)
     {
-        if (! Schema::hasColumn($model->getTable(), $model->getUuidColumnName())) {
+        if (! $model->getConnection()->getSchemaBuilder()->hasColumn($model->getTable(), $model->getUuidColumnName())) {
             throw new MissingUuidColumnException("You don't have a '{$model->getUuidColumnName()}' column on '{$model->getTable()}' table.");
         }
     }

--- a/tests/Feature/OtherConnectionUserHasUuidTest.php
+++ b/tests/Feature/OtherConnectionUserHasUuidTest.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of eloquent-uuid.
+ *
+ * (c) YourApp.Rocks <contact@yourapp.rocks>
+ *
+ * This source file is subject to the license file that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace YourAppRocks\EloquentUuid\Test\Feature;
+
+use YourAppRocks\EloquentUuid\Tests\Models\OtherConnectionUser;
+use YourAppRocks\EloquentUuid\Tests\TestCase;
+
+class OtherConnectionUserHasUuidTest extends TestCase
+{
+    /** @test */
+    public function can_generate_uuid_on_other_connection()
+    {
+        $user = OtherConnectionUser::create(['name' => 'João Roberto']);
+        $this->assertNotEmpty($user->getUuid());
+    }
+}

--- a/tests/Models/OtherConnectionUser.php
+++ b/tests/Models/OtherConnectionUser.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of eloquent-uuid.
+ *
+ * (c) YourApp.Rocks <contact@yourapp.rocks>
+ *
+ * This source file is subject to the license file that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace YourAppRocks\EloquentUuid\Tests\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use YourAppRocks\EloquentUuid\Traits\HasUuid;
+
+class OtherConnectionUser extends Model
+{
+    use HasUuid;
+
+    protected $table = 'other_connection_users';
+
+    protected $connection = 'other-connection';
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,6 +31,13 @@ class TestCase extends Orchestra
             'database' => ':memory:',
             'prefix' => '',
         ]);
+
+        $app['config']->set('database.other-connection', 'sqlite');
+        $app['config']->set('database.connections.other-connection', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 
     protected function setUpDatabase()
@@ -45,6 +52,13 @@ class TestCase extends Orchestra
         Schema::dropIfExists('custom_users');
         Schema::create('custom_users', function (Blueprint $table) {
             $table->uuid('userid');
+            $table->string('name')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('other-connection')->dropIfExists('other_connection_users');
+        Schema::connection('other-connection')->create('other_connection_users', function ($table) {
+            $table->uuid('uuid');
             $table->string('name')->nullable();
             $table->timestamps();
         });


### PR DESCRIPTION
## Description
This PR fix the use of HasUuid trait in a model wich a connection different than default using model connection to verify if a uuid column exists in database.

## Motivation and context
Currently the method `hasColumnUuid()` does not use model connection to verify `hasTable()` and `MissingUuidColumnException` will always be thrown because of using default connection.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)